### PR TITLE
Add test pass criteria for HTML5 Els

### DIFF
--- a/test-files/article.html
+++ b/test-files/article.html
@@ -6,6 +6,24 @@
 	</head>
 	<body>
 		<h1><code>article</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+			</ul>
+		</div>
+
+		<div class="reference">
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html5/sections.html#the-article-element">HTML5 article element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-article">HTML Accessibility API Mappings for article element</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-article">Core Accessibility API Mappings for article role</a></li>
+			</ul>
+		</div>
+
 		<ul>
 			<li>Plain</li>
 			<li>With <code>&lt;h1></code></li>
@@ -47,12 +65,5 @@
 	&lt;h1 id="article-title">Once upon a time&lt;/h1>
 	Lorem ipsum...
 &lt;/article></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html5/sections.html#the-article-element">HTML5 article element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-article">HTML Accessibility API Mappings for article element</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-article">Core Accessibility API Mappings for article role</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/aside.html
+++ b/test-files/aside.html
@@ -6,6 +6,24 @@
 	</head>
 	<body>
 		<h1><code>aside</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+			</ul>
+		</div>
+
+		<div class="reference">
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html/grouping-content.html#the-aside-element">HTML5 aside element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-aside">HTML Accessibility API Mappings for aside element</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-complementary">Core Accessibility API Mappings for complementary role</a></li>
+			</ul>
+		</div>
+
 		<ul>
 			<li>Plain</li>
 			<li>With <code>&lt;h1></code></li>
@@ -47,12 +65,5 @@
 	&lt;h1 id="aside-title">Once upon a time&lt;/h1>
 	Lorem ipsum...
 &lt;/aside></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html/grouping-content.html#the-aside-element">HTML5 aside element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-aside">HTML Accessibility API Mappings for aside element</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-complementary">Core Accessibility API Mappings for complementary role</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/audio.html
+++ b/test-files/audio.html
@@ -6,6 +6,24 @@
 	</head>
 	<body>
 		<h1><code>audio</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+				<li>#3: Controls are keyboard accessible</li>
+			</ul>
+		</div>
+
+		<div class="reference">
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-audio-element">HTML5 audio element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-audio">HTML Accessibility API Mappings for audio element</a></li>
+			</ul>
+		</div>
+
 		<p>
 			<audio controls>
 				<source src="../audio/jeffbob.mp3" type="audio/mpeg">
@@ -19,11 +37,6 @@
 	&lt;source src="audio/jeffbob.ogg" type="audio/ogg">
 &lt;/audio></pre>
 
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-audio-element">HTML5 audio element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-audio">HTML Accessibility API Mappings for audio element</a></li>
-			<li>Audio file: <a href="https://archive.org/details/Jeffbob">Spam call: Bob hangs up 7 mins into his survey</a> by Bruce Lawson</li>
-		</ul>
+		<p>Audio file: <a href="https://archive.org/details/Jeffbob">Spam call: Bob hangs up 7 mins into his survey</a> by Bruce Lawson</p>
 	</body>
 </html>

--- a/test-files/canvas.html
+++ b/test-files/canvas.html
@@ -6,7 +6,27 @@
 	</head>
 	<body>
 		<h1><code>canvas</code> element</h1>
-				<canvas id="myCanvas" width="338" height="258">
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: <code>drawFocusIfNeeded()</code> is supported</li>
+				<li>#3: Element has correct HTML and Core Accessibility API mappings</li>
+				<li>#4: Canvas sub-DOM is exposed</li>
+			</ul>
+		</div>
+
+		<div class="reference">
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html5/scripting-1.html#the-canvas-element">HTML5 canvas element</a></li>
+				<li><a href="https://www.w3.org/TR/2dcontext/#dom-context-2d-drawfocusifneeded">drawFocusIfNeeded()</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-canvas">HTML Accessibility API Mappings for canvas element</a></li>
+			</ul>
+		</div>
+				
+		<canvas id="myCanvas" width="338" height="258">
 			<p>The woman in the painting is wearing a flowing white dress. A large piece of intricately
 			   patterned fabric is draped over the side. In her right hand she holds the chain mooring the boat. Her expression
 			   is mournful. She stares at a crucifix lying in front of her. Beside it are three candles. Two have blown out.
@@ -30,11 +50,5 @@
 	   patterned fabric is draped over the side. In her right hand she holds the chain mooring the boat. Her expression <br>
 	   is mournful. She stares at a crucifix lying in front of her. Beside it are three candles. Two have blown out.&lt;/p><br>
 &lt;/canvas></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html5/scripting-1.html#the-canvas-element">HTML5 canvas element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-canvas">HTML Accessibility API Mappings for canvas element</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/datalist.html
+++ b/test-files/datalist.html
@@ -6,6 +6,26 @@
 	</head>
 	<body>
 		<h1><code>input</code> element + <code>datalist</code> elmement</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+				<li>#3: Control is keyboard accessible</li>
+			</ul>
+		</div>
+
+		<div class="reference">
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html/forms.html#the-datalist-element">HTML5 datalist element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-datalist">HTML Accessibility API Mappings for datalist element</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-listbox">Core Accessibility API Mappings for listbox role</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#ariaMultiselectableFalse">Core Accessibility API Mappings for aria-multiselectable="false"</a></li>
+			</ul>
+		</div>
+
 		<label>sites <input list="hpurls" placeholder="text+list" type="text"></label>
 		<datalist id="hpurls">
 			<option value="http://www.google.com/" label="Google">Google</option>
@@ -18,13 +38,5 @@
 	&lt;option value="http://www.google.com/" label="Google">&lt;/option><br>
 	&lt;option value="http://www.reddit.com/" label="Reddit">&lt;/option><br>
 &lt;/datalist></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html/forms.html#the-datalist-element">HTML5 datalist element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-datalist">HTML Accessibility API Mappings for datalist element</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-listbox">Core Accessibility API Mappings for listbox role</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#ariaMultiselectableFalse">Core Accessibility API Mappings for aria-multiselectable="false"</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/details-summary.html
+++ b/test-files/details-summary.html
@@ -6,6 +6,26 @@
 	</head>
 	<body>
 		<h1><code>details</code> element with <code>summary</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Elements are supported</li>
+				<li>#2: Elements have correct HTML and Core Accessibility API mappings</li>
+				<li>#3: Control is keyboard accessible</li>
+			</ul>
+		</div>
+
+		<div class="reference">
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html51/semantics.html#the-details-element">HTML5.1 details element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-details">HTML Accessibility API Mappings for details element</a></li>
+				<li><a href="http://www.w3.org/TR/html51/semantics.html#the-summary-element">HTML5.1 summary element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-summary">HTML Accessibility API Mappings for summary element</a></li>
+			</ul>
+		</div>
+
 		<details>
 			<summary>Why use HTML5?</summary>
 			<p>You should use HTML5 because...</p>
@@ -16,13 +36,5 @@
 	&lt;summary>Why use HTML5?&lt;/summary>
 	&lt;p>You should use HTML5 because...&lt;/p>
 &lt;/details></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html51/semantics.html#the-details-element">HTML5.1 details element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-details">HTML Accessibility API Mappings for details element</a></li>
-			<li><a href="http://www.w3.org/TR/html51/semantics.html#the-summary-element">HTML5.1 summary element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-summary">HTML Accessibility API Mappings for summary element</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/figure-figcaption.html
+++ b/test-files/figure-figcaption.html
@@ -6,6 +6,25 @@
 	</head>
 	<body>
 		<h1><code>figure</code> element with <code>figcaption</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Elements are supported</li>
+				<li>#2: Elements have correct HTML and Core Accessibility API mappings</li>
+			</ul>
+		</div>
+
+		<div class="reference">
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html/grouping-content.html#the-figure-element">HTML5 figure element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-figure">HTML Accessibility API Mappings for figure element</a></li>
+				<li><a href="http://www.w3.org/TR/html/grouping-content.html#the-figcaption-element">HTML5 figcaption element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-figcaption">HTML Accessibility API Mappings for figcaption element</a></li>
+			</ul>
+		</div>
+
 		<p>
 			<figure>
 				<img src="../images/HTML5_Logo.png" alt="HTML5 logo" width="128" height="128">
@@ -18,13 +37,5 @@
 	&lt;img src="../images/HTML5_Logo.png" alt="HTML5 logo" width="128" height="128">
 	&lt;figcaption>HTML5 logo&lt;/figcaption>
 &lt;/figure></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html/grouping-content.html#the-figure-element">HTML5 figure element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-figure">HTML Accessibility API Mappings for figure element</a></li>
-			<li><a href="http://www.w3.org/TR/html/grouping-content.html#the-figcaption-element">HTML5 figcaption element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-figcaption">HTML Accessibility API Mappings for figcaption element</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/figure.html
+++ b/test-files/figure.html
@@ -6,6 +6,23 @@
 	</head>
 	<body>
 		<h1><code>figure</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+			</ul>
+		</div>
+
+		<div class="reference">
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html/grouping-content.html#the-figure-element">HTML5 figure element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-figure">HTML Accessibility API Mappings for figure element</a></li>
+			</ul>
+		</div>
+					
 		<p>
 			<figure>
 				<img src="../images/HTML5_Logo.png" alt="HTML5 logo" width="128" height="128">

--- a/test-files/footer.html
+++ b/test-files/footer.html
@@ -6,6 +6,25 @@
 	</head>
 	<body>
 		<h1><code>footer</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+			</ul>
+		</div>
+
+		<div class="reference">
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html/sections.html#the-footer-element">HTML5 footer element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-footer-ancestorbody">HTML Accessibility API Mappings for footer element (nearest sectioning content/root is body)</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-contentinfo">Core Accessibility API Mappings for contentinfo role</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-footer">HTML Accessibility API Mappings for footer element (nearest sectioning content/root is not body)</a></li>
+			</ul>
+		</div>
+		
 		<footer>Lorem ipsum...</footer>
 
 		<article>
@@ -18,13 +37,5 @@
 		<pre><code>&lt;article>
 	&lt;footer>Lorem ipsum...&lt;/footer>
 &lt;/article></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html/sections.html#the-footer-element">HTML5 footer element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-footer-ancestorbody">HTML Accessibility API Mappings for footer element (nearest sectioning content/root is body)</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-contentinfo">Core Accessibility API Mappings for contentinfo role</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-footer">HTML Accessibility API Mappings for footer element (nearest sectioning content/root is not body)</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/header.html
+++ b/test-files/header.html
@@ -9,6 +9,24 @@
 			<h1><code>header</code> element</h1>
 		</header>
 
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+			</ul>
+		</div>
+
+		<div class="reference">		
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html/sections.html#the-header-element">HTML5 header element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-header-ancestorbody">HTML Accessibility API Mappings for header element (nearest sectioning content/root is body)</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-banner">Core Accessibility API Mappings for banner role</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-header">HTML Accessibility API Mappings for header element (nearest sectioning content/root is not body)</a></li>
+			</ul>
+		</div>
+
 		<article>
 			<header>
 				<h2>Example header</h2>
@@ -27,13 +45,5 @@
 	&lt;/header>
 	...
 &lt;/article></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html/sections.html#the-header-element">HTML5 header element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-header-ancestorbody">HTML Accessibility API Mappings for header element (nearest sectioning content/root is body)</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-banner">Core Accessibility API Mappings for banner role</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-header">HTML Accessibility API Mappings for header element (nearest sectioning content/root is not body)</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/input--time.html
+++ b/test-files/input--time.html
@@ -6,6 +6,24 @@
 	</head>
 	<body>
 		<h1><code>input type=time</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+				<li>#3: Control is keyboard accessible</li>
+			</ul>
+		</div>
+
+		<div class="reference">	
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html5/forms.html#time-state-(type=time)">HTML5 input type=time element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-time">HTML Accessibility API Mappings for input type=time element</a></li>
+			</ul>
+		</div>
+
 		<form>
 			<p><input type="time"></p>
 
@@ -29,11 +47,5 @@
 
 		<h2>Code</h2>
 		<p>&lt;label>time of birth &lt;input type="time">&lt;/label></p>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html5/forms.html#time-state-(type=time)">HTML5 input type=time element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-time">HTML Accessibility API Mappings for input type=time element</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/input-color.html
+++ b/test-files/input-color.html
@@ -6,6 +6,24 @@
 	</head>
 	<body>
 		<h1><code>input type=color</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+				<li>#3: Control is keyboard accessible</li>
+			</ul>
+		</div>
+
+		<div class="reference">	
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html5/forms.html#color-state-(type=color)">HTML5 input type=color element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-color">HTML Accessibility API Mappings for input type=color element</a></li>
+			</ul>
+		</div>
+
 		<p><input type="color"></p>
 
 		<h2> with label</h2>
@@ -22,11 +40,5 @@
 
 		<h2>Code</h2>
 		<pre data-number=""><code>&lt;label for="col">choose a shade&lt;/label><br>&lt;input id="col" type="color"></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html5/forms.html#color-state-(type=color)">HTML5 input type=color element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-color">HTML Accessibility API Mappings for input type=color element</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/input-date.html
+++ b/test-files/input-date.html
@@ -6,6 +6,24 @@
 	</head>
 	<body>
 		<h1><code>input type=date</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+				<li>#3: Control is keyboard accessible</li>
+			</ul>
+		</div>
+
+		<div class="reference">	
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html5/forms.html#date-state-(type=date)">HTML5 input type=date element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-date">HTML Accessibility API Mappings for input type=date element</a></li>
+			</ul>
+		</div>
+			
 		<p><input type="date"></p>
 
 		<h2>with label </h2>
@@ -22,11 +40,5 @@
 
 		<h2>Code</h2>
 		<p>&lt;label>date of birth &lt;input type="date">&lt;/label></p>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html5/forms.html#date-state-(type=date)">HTML5 input type=date element</a>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-date">HTML Accessibility API Mappings for input type=date element</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/input-email.html
+++ b/test-files/input-email.html
@@ -6,6 +6,28 @@
 	</head>
 	<body>
 		<h1><code>input type=email</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+				<li>#3: Control is keyboard accessible</li>
+			</ul>
+		</div>
+
+		<div class="reference">	
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html/forms.html#e-mail-state-(type=email)">HTML5 input type=email element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-email">HTML Accessibility API Mappings for input type=email element without list attribute</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-textbox">Core Accessibility API Mappings for textbox role</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-textetc-autocomplete">HTML Accessibility API Mappings for input type=email element with list attribute</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-combobox">Core Accessibility API Mappings for combobox role</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#ariaOwns">Core Accessibility API Mappings for aria-owns property</a></li>
+			</ul>
+		</div>
+
 		<p><input type="email"></p>
 
 		<h2>with label </h2>
@@ -25,15 +47,5 @@
 
 		<h2>Code</h2>
 		<p>&lt;label>sign up &lt;input type="email">&lt;/label></p>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html/forms.html#e-mail-state-(type=email)">HTML5 input type=email element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-email">HTML Accessibility API Mappings for input type=email element without list attribute</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-textbox">Core Accessibility API Mappings for textbox role</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-textetc-autocomplete">HTML Accessibility API Mappings for input type=email element with list attribute</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-combobox">Core Accessibility API Mappings for combobox role</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#ariaOwns">Core Accessibility API Mappings for aria-owns property</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/input-month.html
+++ b/test-files/input-month.html
@@ -6,6 +6,24 @@
 	</head>
 	<body>
 		<h1><code>input type=month</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+				<li>#3: Control is keyboard accessible</li>
+			</ul>
+		</div>
+
+		<div class="reference">	
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html5/forms.html#date-state-(type=month)">HTML5 input type=month element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-input-month">HTML Accessibility API Mappings for input type=month element</a></li>
+			</ul>
+		</div>
+
 		<p><input type="month"></p>
 
 		<h2>with label </h2>
@@ -25,11 +43,5 @@
 
 		<h2>Code</h2>
 		<pre><code>&lt;label>month of birth &lt;input type="month">&lt;/label></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html5/forms.html#date-state-(type=month)">HTML5 input type=month element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-input-month">HTML Accessibility API Mappings for input type=month element</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/input-number.html
+++ b/test-files/input-number.html
@@ -6,6 +6,25 @@
 	</head>
 	<body>
 		<h1><code>input type=number</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+				<li>#3: Control is keyboard accessible</li>
+			</ul>
+		</div>
+
+		<div class="reference">	
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html/forms.html#number-state-(type=number)">HTML5 input type=number element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-number">HTML Accessibility API Mappings for input type=number element</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-spinbutton">Core Accessibility API Mappings for spinbutton role</a></li>
+			</ul>
+		</div>
+
 		<p><input type="number"></p>
 
 		<h2>with label </h2>
@@ -40,12 +59,5 @@
 
 		<h2>Code</h2>
 		<p>&lt;label>amount &lt;input type="number">&lt;/label></p>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html/forms.html#number-state-(type=number)">HTML5 input type=number element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-number">HTML Accessibility API Mappings for input type=number element</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-spinbutton">Core Accessibility API Mappings for spinbutton role</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/input-range.html
+++ b/test-files/input-range.html
@@ -6,6 +6,25 @@
 	</head>
 	<body>
 		<h1><code>input type=range</code> element</h1>
+		
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+				<li>#3: Control is keyboard accessible</li>
+			</ul>
+		</div>
+
+		<div class="reference">	
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html/forms.html#range-state-%28type=range%29">HTML5 input type=range element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-range">HTML Accessibility API Mappings for input type=range element</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-slider">Core Accessibility API Mappings for slider role</a></li>
+			</ul>
+		</div>
+
 		<p><input type="range" min="-100" max="100" value="10" step="10"></p>
 
 		<h2>with label </h2>
@@ -22,12 +41,5 @@
 
 		<h2>Code</h2>
 		<p>&lt;label>temperature &lt;input type="range" min="-100" max="100" value="10" step="10">&lt;/label></p>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html/forms.html#range-state-%28type=range%29">HTML5 input type=range element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-range">HTML Accessibility API Mappings for input type=range element</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-slider">Core Accessibility API Mappings for slider role</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/input-search.html
+++ b/test-files/input-search.html
@@ -6,6 +6,28 @@
 	</head>
 	<body>
 		<h1><code>input type=search</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+				<li>#3: Control is keyboard accessible</li>
+			</ul>
+		</div>
+
+		<div class="reference">	
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html/forms.html#text-%28type=text%29-state-and-search-state-%28type=search%29">HTML5 input type=search element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-search">HTML Accessibility API Mappings for input type=search element</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-textbox">Core Accessibility API Mappings for textbox role</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-textetc-autocomplete">HTML Accessibility API Mappings for input type=search element with list attribute</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-combobox">Core Accessibility API Mappings for combobox role</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#ariaOwns">Core Accessibility API Mappings for aria-owns property</a></li>
+			</ul>
+		</div>
+
 		<form>
 			<p><input type="search"></p>
 
@@ -29,15 +51,5 @@
 
 		<h2>Code</h2>
 		<pre><code>&lt;label>site search &lt;input type="search">&lt;/label></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html/forms.html#text-%28type=text%29-state-and-search-state-%28type=search%29">HTML5 input type=search element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-search">HTML Accessibility API Mappings for input type=search element</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-textbox">Core Accessibility API Mappings for textbox role</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-textetc-autocomplete">HTML Accessibility API Mappings for input type=search element with list attribute</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-combobox">Core Accessibility API Mappings for combobox role</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#ariaOwns">Core Accessibility API Mappings for aria-owns property</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/input-tel.html
+++ b/test-files/input-tel.html
@@ -6,6 +6,28 @@
 	</head>
 	<body>
 		<h1><code>input type=tel</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+				<li>#3: Control is keyboard accessible</li>
+			</ul>
+		</div>
+
+		<div class="reference">	
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html/forms.html#telephone-state-(type=tel)">HTML5 input type=tel element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-tel">HTML Accessibility API Mappings for input type=tel element without list attribute</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-textbox">Core Accessibility API Mappings for textbox role</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-textetc-autocomplete">HTML Accessibility API Mappings for input type=tel element with list attribute</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-combobox">Core Accessibility API Mappings for combobox role</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#ariaOwns">Core Accessibility API Mappings for aria-owns property</a></li>
+			</ul>
+		</div>
+
 		<form>
 			<p><input type="tel"></p>
 
@@ -29,15 +51,5 @@
 
 		<h2>Code</h2>
 		<pre><code>&lt;label>home phone &lt;input type="tel">&lt;/label></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html/forms.html#telephone-state-(type=tel)">HTML5 input type=tel element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-tel">HTML Accessibility API Mappings for input type=tel element without list attribute</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-textbox">Core Accessibility API Mappings for textbox role</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-textetc-autocomplete">HTML Accessibility API Mappings for input type=tel element with list attribute</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-combobox">Core Accessibility API Mappings for combobox role</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#ariaOwns">Core Accessibility API Mappings for aria-owns property</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/input-url.html
+++ b/test-files/input-url.html
@@ -6,6 +6,28 @@
 	</head>
 	<body>
 		<h1><code>input type=url</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+				<li>#3: Control is keyboard accessible</li>
+			</ul>
+		</div>
+
+		<div class="reference">
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html/forms.html#url-state-(type=url)">HTML5 input type=url element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-url">HTML Accessibility API Mappings for input type=url element without list attribute</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-textbox">Core Accessibility API Mappings for textbox role</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-textetc-autocomplete">HTML Accessibility API Mappings for input type=url element with list attribute</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-combobox">Core Accessibility API Mappings for combobox role</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#ariaOwns">Core Accessibility API Mappings for aria-owns property</a></li>
+			</ul>
+		</div>
+
 		<form>
 			<p><input type="url"></p>
 
@@ -29,15 +51,5 @@
 
 		<h2>Code</h2>
 		<pre><code>&lt;label>your web site &lt;input type="url">&lt;/label></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html/forms.html#url-state-(type=url)">HTML5 input type=url element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-url">HTML Accessibility API Mappings for input type=url element without list attribute</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-textbox">Core Accessibility API Mappings for textbox role</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-textetc-autocomplete">HTML Accessibility API Mappings for input type=url element with list attribute</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-combobox">Core Accessibility API Mappings for combobox role</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#ariaOwns">Core Accessibility API Mappings for aria-owns property</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/input-week.html
+++ b/test-files/input-week.html
@@ -6,6 +6,24 @@
 	</head>
 	<body>
 		<h1><code>input type=week</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+				<li>#3: Control is keyboard accessible</li>
+			</ul>
+		</div>
+
+		<div class="reference">
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html51/semantics.html#week-state-(type=week)">HTML5 input type=week element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-week">HTML Accessibility API Mappings for input type=week element</a></li>
+			</ul>
+		</div>
+
 		<form>
 			<p><input type="week"></p>
 
@@ -26,11 +44,5 @@
 
 		<h2>Code</h2>
 		<pre><code>&lt;label>week of birth &lt;input type="week">&lt;/label></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html51/semantics.html#week-state-(type=week)">HTML5 input type=week element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-input-week">HTML Accessibility API Mappings for input type=week element</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/main.html
+++ b/test-files/main.html
@@ -6,6 +6,23 @@
 	</head>
 	<body>
 		<h1><code>main</code> element</h1>
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+			</ul>
+		</div>
+
+		<div class="reference">
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html5/grouping-content.html#the-main-element">HTML5 main element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-main">HTML Accessibility API Mappings for main element</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-main">Core Accessibility API Mappings for main role</a></li>
+			</ul>
+		</div>
+
 		<main>
 			<h2>Skateboards</h2>
 			<p>The skateboard is the way cool kids get around</p>
@@ -34,12 +51,5 @@
 	by means of the feet; rather an electric motor propels the board,
 	fed by an electric battery.&lt;/p>
 &lt;/main></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html5/grouping-content.html#the-main-element">HTML5 main element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-main">HTML Accessibility API Mappings for main element</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-main">Core Accessibility API Mappings for main role</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/mark.html
+++ b/test-files/mark.html
@@ -6,15 +6,26 @@
 	</head>
 	<body>
 		<h1><code>mark</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+			</ul>
+		</div>
+
+		<div class="reference">
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html5/text-level-semantics.html#the-mark-element">HTML5 mark element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-mark">HTML Accessibility API Mappings for mark element</a></li>
+			</ul>
+		</div>
+			
 		<p><mark>This text</mark> is marked as highlighted</p>
 
 		<h2>Code</h2>
 		<pre><code>&lt;p>&lt;mark>This text&lt;/mark> is marked as highlighted&lt;/p></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html5/text-level-semantics.html#the-mark-element">HTML5 mark element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-mark">HTML Accessibility API Mappings for mark element</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/meter.html
+++ b/test-files/meter.html
@@ -6,15 +6,26 @@
 	</head>
 	<body>
 		<h1><code>meter</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+			</ul>
+		</div>
+
+		<div class="reference">
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html5/forms.html#the-meter-element">HTML5 meter element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-meter">HTML Accessibility API Mappings for meter element</a></li>
+			</ul>
+		</div>
+
 		<p><meter min="0" max="100" value="83.5">fallback content</meter></p>
 
 		<h2>Code</h2>
 		<pre><code>&lt;p>&lt;meter min="0" max="100" value="83.5">fallback content&lt;/meter>&lt;/p></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html5/forms.html#the-meter-element">HTML5 meter element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-meter">HTML Accessibility API Mappings for meter element</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/nav.html
+++ b/test-files/nav.html
@@ -6,6 +6,24 @@
 	</head>
 	<body>
 		<h1><code>nav</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+			</ul>
+		</div>
+
+		<div class="reference">
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html5/sections.html#the-nav-element">HTML5 nav element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-nav">HTML Accessibility API Mappings for nav element</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-navigation">Core Accessibility API Mappings for navigation role</a></li>
+			</ul>
+		</div>
+
 		<nav>
 			<h2>You are here:</h2>
 			<ul id="navlist">
@@ -26,12 +44,5 @@
 		&lt;li>&lt;a>Second hand&lt;/a>&lt;/li>
 	&lt;/ul>
 &lt;/nav></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html5/sections.html#the-nav-element">HTML5 nav element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-nav">HTML Accessibility API Mappings for nav element</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-navigation">Core Accessibility API Mappings for navigation role</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/output.html
+++ b/test-files/output.html
@@ -6,6 +6,24 @@
 	</head>
 	<body>
 		<h1><code>output</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+			</ul>
+		</div>
+
+		<div class="reference">
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html5/forms.html#the-output-element">HTML5 output element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-output">HTML Accessibility API Mappings for output element</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-status">Core Accessibility API Mappings for status role</a></li>
+			</ul>
+		</div>
+
 		<p><form oninput="result.value=parseInt(a.value)+parseInt(b.value)">
 			<input type="range" name="b" value="50" /> +
 			<input type="number" name="a" value="10" /> =
@@ -18,12 +36,5 @@
 	&lt;input type="number" name="a" id="a" value="10" /> =<br>
 	&lt;output name="result" for="b a">&lt;/output><br>
 &lt;/form></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html5/forms.html#the-output-element">HTML5 output element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-output">HTML Accessibility API Mappings for output element</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-status">Core Accessibility API Mappings for status role</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/progress.html
+++ b/test-files/progress.html
@@ -6,20 +6,31 @@
 	</head>
 	<body>
 		<h1><code>progress</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+			</ul>
+		</div>
+
+		<div class="reference">
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html5/forms.html#the-progress-element">HTML5 progress element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-progress">HTML Accessibility API Mappings for progress element</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-progressbar">Core Accessibility API Mappings for progressbar role</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#ariaValueMax">Core Accessibility API Mappings for aria-valuemax property</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#ariaValueMin">Core Accessibility API Mappings for aria-valuemin property</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#ariaValueNow">Core Accessibility API Mappings for aria-valuenow property</a></li>
+			</ul>
+		</div>
+		
 		<p>Downloading progress:
 		<progress value="22" max="100"></progress></p>
 
 		<h2>Code</h2>
 		<pre><code>&lt;p>Downloading progress: &lt;progress value="22" max="100">&lt;/progress>&lt;/p></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html5/forms.html#the-progress-element">HTML5 progress element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-progress">HTML Accessibility API Mappings for progress element</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-progressbar">Core Accessibility API Mappings for progressbar role</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#ariaValueMax">Core Accessibility API Mappings for aria-valuemax property</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#ariaValueMin">Core Accessibility API Mappings for aria-valuemin property</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#ariaValueNow">Core Accessibility API Mappings for aria-valuenow property</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/section.html
+++ b/test-files/section.html
@@ -6,6 +6,24 @@
 	</head>
 	<body>
 		<h1><code>section</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+			</ul>
+		</div>
+
+		<div class="reference">
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html5/sections.html#the-section-element">HTML5 section element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-section">HTML Accessibility API Mappings for section element</a></li>
+				<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-region">Core Accessibility API Mappings for region role</a></li>
+			</ul>
+		</div>
+
 		<ul>
 			<li>Plain</li>
 			<li>With <code>&lt;h1></code></li>
@@ -55,12 +73,5 @@
 	&lt;h1 id="section-title">Once upon a time&lt;/h1>
 	Lorem ipsum...
 &lt;/section></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html5/sections.html#the-section-element">HTML5 section element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-section">HTML Accessibility API Mappings for section element</a></li>
-			<li><a href="https://www.w3.org/TR/core-aam-1.1/#role-map-region">Core Accessibility API Mappings for region role</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/time.html
+++ b/test-files/time.html
@@ -6,17 +6,28 @@
 	</head>
 	<body>
 		<h1><code>time</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Element is supported</li>
+				<li>#2: Element has correct HTML and Core Accessibility API mappings</li>
+			</ul>
+		</div>
+
+		<div class="reference">
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html/text-level-semantics.html#the-time-element">HTML5 time element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-time">HTML Accessibility API Mappings for time element</a></li>
+			</ul>
+		</div>
+
 		<p>HTML5, published on <time datetime="2014-10-28">October 28 2015</time>,
 		has really good accessibility.</p>
 
 		<h2>Code</h2>
 		<pre><code>&lt;p>HTML5, published on &lt;time datetime="2014-10-28">October 28 2015&lt;/time>,
  has really good accessibility.&lt;/p></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html/text-level-semantics.html#the-time-element">HTML5 time element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-time">HTML Accessibility API Mappings for time element</a></li>
-		</ul>
 	</body>
 </html>

--- a/test-files/video.html
+++ b/test-files/video.html
@@ -6,6 +6,26 @@
 	</head>
 	<body>
 		<h1><code>video</code> + <code>track</code> element</h1>
+
+		<div class="criteria">
+			<h2>Pass Criteria</h2>
+			<ul>
+				<li>#1: Elements are supported</li>
+				<li>#2: Elementa have correct HTML and Core Accessibility API mappings</li>
+				<li>#3: Controls are keyboard accessible</li>
+			</ul>
+		</div>
+
+		<div class="reference">
+			<h2>Reference</h2>
+			<ul>
+				<li><a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-video-element">HTML5 video element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-video">HTML Accessibility API Mappings for video element</a></li>
+				<li><a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-track-element">HTML5 track element</a></li>
+				<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-track">HTML Accessibility API Mappings for track element</a></li>
+			</ul>
+		</div>
+
 		<p>
 			<video controls width="300" height="300">
   				<source src="../images/elo.mp4" type="video/mp4">
@@ -20,13 +40,5 @@
 	&lt;source src="../images/elo.ogg" type="video/ogg">
 	&lt;track kind="captions" srclang="en" src="../images/elo.vtt" label="English">
 &lt;/video></code></pre>
-
-		<h2>Reference</h2>
-		<ul>
-			<li><a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-video-element">HTML5 video element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-video">HTML Accessibility API Mappings for video element</a></li>
-			<li><a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-track-element">HTML5 track element</a></li>
-			<li><a href="https://www.w3.org/TR/html-aam-1.0/#el-track">HTML Accessibility API Mappings for track element</a></li>
-		</ul>
 	</body>
 </html>


### PR DESCRIPTION
- Added pass criteria to HTML5 elements so it is more clear what is
  needed to pass HTML5Accessibility tests
- Moved references up to top for those tests to keep them close to the
  pass criteria, and a preparation for the wider design change proposal
  in development (may as well do at same time to avoid doing twice)

Notes:
- used ul instead of ol for criteria as order doesn’t really matter
  except perhaps the first one. Just giving a number to make criteria
  easier to refer to.
- Exact text can be decided later, this is just a first pass to help
  devs test
- Test criteria needs checked to make sure they’re correct and there is
  nothing missing
- Didn’t use HTML5 section elements as don’t want to interfere with
  tests by adding extra semantics.
