### PR TITLE
Fix menu/menuitem tests for Firefox

### DIFF
--- a/test-files/menu-context.html
+++ b/test-files/menu-context.html
@@ -36,14 +36,14 @@
 			<h2 class="test-title" id="mc-001">Test mc-001: Menu element with type="context"</h2>
 
 			<div class="test-case">
-				<button id="menu-button1" menu="menu1">I have a context menu. Right click (or equivalent) to test</button>
+				<div id="menu-button1" contextmenu="menu1">I have a context menu. Right click (or equivalent) to test</div>
 				<menu type="context" id="menu1">
 					<menuitem label="I’m a menuitem" />
 				</menu>
 			</div>
 			
 			<h3 class="code-title">Code</h3>
-			<pre><code>&lt;button id="menu-button1" menu="menu1">I have a context menu. Right click (or equivalent) to test&lt;/button>
+			<pre><code>&lt;div id="menu-button1" contextmenu="menu1">I have a context menu. Right click (or equivalent) to test&lt;/div>
 &lt;menu type="context" id="menu1">
 	&lt;menuitem label="I’m a menuitem" />
 &lt;/menu></code></pre>

--- a/test-files/menuitem.html
+++ b/test-files/menuitem.html
@@ -62,11 +62,13 @@
 		<div class="test">
 			<h2 class="test-title" id="mi-002">Test mi-002: Menuitem element with type="checkbox"</h2>
 
-			<div id="menu2" contextmenu="checkbox-menu">I have a number of checkbox menuitems in my context menu. Right click (or equivalent) to test</div>
-			<menu type="context" id="checkbox-menu">
-				<menuitem type="checkbox" label="I’m a checkbox menuitem" checked />
-				<menuitem type="checkbox" label="I’m another checkbox menuitem" />
-			</menu>
+			<div class="test-case">
+				<div id="menu2" contextmenu="checkbox-menu">I have a number of checkbox menuitems in my context menu. Right click (or equivalent) to test</div>
+				<menu type="context" id="checkbox-menu">
+					<menuitem type="checkbox" label="I’m a checkbox menuitem" checked />
+					<menuitem type="checkbox" label="I’m another checkbox menuitem" />
+				</menu>
+			</div>
 			
 			<h3 class="code-title">Code</h3>
 			<pre><code>&lt;div id="menu2" contextmenu="checkbox-menu">I have a number of checkbox menuitems in my context menu. Right click (or equivalent) to test&lt;/div>
@@ -79,11 +81,13 @@
 		<div class="test">
 			<h2 class="test-title" id="mi-003">Test mi-003: Menuitem element with type="radio"</h2>
 
-			<div id="menu3" contextmenu="radio-menu">I have a number of radio menuitems in my context menu. Right click (or equivalent) to test</div>
-			<menu type="context" id="radio-menu">
-				<menuitem type="radio" radiogroup="radios" label="I’m a radio menuitem" checked />
-				<menuitem type="radio" radiogroup="radios" label="I’m another radio menuitem" />
-			</menu>
+			<div class="test-case">
+				<div id="menu3" contextmenu="radio-menu">I have a number of radio menuitems in my context menu. Right click (or equivalent) to test</div>
+				<menu type="context" id="radio-menu">
+					<menuitem type="radio" radiogroup="radios" label="I’m a radio menuitem" checked />
+					<menuitem type="radio" radiogroup="radios" label="I’m another radio menuitem" />
+				</menu>
+			</div>
 			
 			<h3 class="code-title">Code</h3>
 			<pre><code>&lt;div id="menu3" contextmenu="radio-menu">I have a number of radio menuitems in my context menu. Right click (or equivalent) to test&lt;/div>

--- a/test-files/menuitem.html
+++ b/test-files/menuitem.html
@@ -44,7 +44,7 @@
 			<h2 class="test-title" id="mi-001">Test mi-001: Menuitem element with type="command"</h2>
 
 			<div class="test-case">
-				<button id="menu1" menu="command-menu">I have a number of command menuitems in my context menu. Right click (or equivalent) to test</button>
+				<div id="menu1" contextmenu="command-menu">I have a number of command menuitems in my context menu. Right click (or equivalent) to test</div>
 				<menu type="context" id="command-menu">
 					<menuitem type="command" label="I’m a command menuitem" id="menuitem1" />
 					<menuitem type="command" label="I’m another command menuitem" />
@@ -52,7 +52,7 @@
 			</div>
 			
 			<h3 class="code-title">Code</h3>
-			<pre><code>&lt;button id="menu1" menu="command-menu">I have a number of command menuitems in my context menu. Right click (or equivalent) to test&lt;/button>
+			<pre><code>&lt;div id="menu1" contextmenu="command-menu">I have a number of command menuitems in my context menu. Right click (or equivalent) to test&lt;/div>
 &lt;menu type="context" id="command-menu">
 	&lt;menuitem type="command" label="I’m a command menuitem" />
 	&lt;menuitem type="command" label="I’m another command menuitem" />
@@ -62,14 +62,14 @@
 		<div class="test">
 			<h2 class="test-title" id="mi-002">Test mi-002: Menuitem element with type="checkbox"</h2>
 
-			<button id="menu2" menu="checkbox-menu">I have a number of checkbox menuitems in my context menu. Right click (or equivalent) to test</button>
+			<div id="menu2" contextmenu="checkbox-menu">I have a number of checkbox menuitems in my context menu. Right click (or equivalent) to test</div>
 			<menu type="context" id="checkbox-menu">
 				<menuitem type="checkbox" label="I’m a checkbox menuitem" checked />
 				<menuitem type="checkbox" label="I’m another checkbox menuitem" />
 			</menu>
 			
 			<h3 class="code-title">Code</h3>
-			<pre><code>&lt;button id="menu2" menu="checkbox-menu">I have a number of checkbox menuitems in my context menu. Right click (or equivalent) to test&lt;/button>
+			<pre><code>&lt;div id="menu2" contextmenu="checkbox-menu">I have a number of checkbox menuitems in my context menu. Right click (or equivalent) to test&lt;/div>
 &lt;menu type="context" id="checkbox-menu">
 	&lt;menuitem type="checkbox" label="I’m a checkbox menuitem" checked />
 	&lt;menuitem type="checkbox" label="I’m another checkbox menuitem" />
@@ -79,14 +79,14 @@
 		<div class="test">
 			<h2 class="test-title" id="mi-003">Test mi-003: Menuitem element with type="radio"</h2>
 
-			<button id="menu3" menu="radio-menu">I have a number of radio menuitems in my context menu. Right click (or equivalent) to test</button>
+			<div id="menu3" contextmenu="radio-menu">I have a number of radio menuitems in my context menu. Right click (or equivalent) to test</div>
 			<menu type="context" id="radio-menu">
 				<menuitem type="radio" radiogroup="radios" label="I’m a radio menuitem" checked />
 				<menuitem type="radio" radiogroup="radios" label="I’m another radio menuitem" />
 			</menu>
 			
 			<h3 class="code-title">Code</h3>
-			<pre><code>&lt;button id="menu3" menu="radio-menu">I have a number of radio menuitems in my context menu. Right click (or equivalent) to test&lt;/button>
+			<pre><code>&lt;div id="menu3" contextmenu="radio-menu">I have a number of radio menuitems in my context menu. Right click (or equivalent) to test&lt;/div>
 &lt;menu type="context" id="radio-menu">
 	&lt;menuitem type="radio" radiogroup="radios" label="I’m a radio menuitem" checked />
 	&lt;menuitem type="radio" radiogroup="radios" label="I’m another radio menuitem" />


### PR DESCRIPTION
Firefox doesn’t support context menu on an actionable element like a or button, only div.

Also change to context menu (right click) rather than regular click on button
