### PR TITLE
Removed test 008 from range & number

### DIFF
--- a/test-files/input-number.html
+++ b/test-files/input-number.html
@@ -135,18 +135,6 @@
 			</div>
 		</div>
 
-
-		<div class="test">
-			<h2 class="test-title" id="ni-008">Test ni-008: Input type="number" with <code>label</code> element &amp; <code>size</code> attribute</h2>
-
-			<div class="test-case">
-<form>
-	<label for="input8">Checking size</label>
-	<input id="input8" type="number" size="3" />
-</form>
-</div>
-		</div>
-
 		<script src="../scripts/test-scripts.js"></script>
 		<script>
 			var test = [],

--- a/test-files/input-range.html
+++ b/test-files/input-range.html
@@ -119,15 +119,6 @@
 			</div>
 		</div>
 
-		<div class="test">
-			<h2 class="test-title" id="ri-008">Test ri-008: Input type="range" with <code>label</code> element &amp; <code>size</code> attribute</h2>
-
-			<div class="test-case">
-<label for="input8">Checking for size</label>
-<input id="input8" type="range" size="3" min="-100" max="100" value="10" step="10" />
-</div>
-		</div>
-
 		<script src="../scripts/test-scripts.js"></script>
 		<script>
 			var test = [],


### PR DESCRIPTION
Currently the range and number tests are testing to ensure that the `size` attribute works and that is not supported per spec.

Here is input type=number for example: https://html.spec.whatwg.org/multipage/input.html#number-state-(type=number)

I'll keep going through these and if I find more I'll submit further PRs